### PR TITLE
카카오 키워드 장소 검색 api

### DIFF
--- a/src/main/java/com/example/project/api/dto/DocumentDto.java
+++ b/src/main/java/com/example/project/api/dto/DocumentDto.java
@@ -26,6 +26,8 @@ public class DocumentDto {
      * address	    Address	    지번 주소 상세 정보
      * road_address	RoadAddress	도로명 주소 상세 정보
      */
+    @JsonProperty("place_name")
+    private String placeName;
 
     @JsonProperty("address_name") // JSON에 있는 address_name 값을 addressName에 넣는다.
     private String addressName;
@@ -35,4 +37,7 @@ public class DocumentDto {
 
     @JsonProperty("x")
     private double longitude;
+
+    @JsonProperty("distance")
+    private double distance;
 }

--- a/src/main/java/com/example/project/api/service/KakaoCategorySearchService.java
+++ b/src/main/java/com/example/project/api/service/KakaoCategorySearchService.java
@@ -1,0 +1,39 @@
+package com.example.project.api.service;
+
+import com.example.project.api.dto.KakaoApiResponseDto;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
+
+import java.net.URI;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class KakaoCategorySearchService {
+
+    private final KakaoUriBuilderService kakaoUriBuilderService;
+
+    private final RestTemplate restTemplate;
+
+    private static final String PHARMACY_CATEGORY = "PM9"; // 약국 카테고리
+
+    @Value("${kakao.rest.api.key}") // application.yml에 있는 값
+    private String kakaoRestApiKey;
+
+    public KakaoApiResponseDto requestPharmacyCategorySearch(double latitude, double longitude, double radius) {
+        URI uri = kakaoUriBuilderService.buildUriByCategorySearch(latitude, longitude, radius, PHARMACY_CATEGORY);
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.set(HttpHeaders.AUTHORIZATION, "KakaoAK " + kakaoRestApiKey);
+        HttpEntity httpEntity = new HttpEntity<>(headers);
+
+        return restTemplate.exchange(uri, HttpMethod.GET, httpEntity, KakaoApiResponseDto.class).getBody();
+
+    }
+}

--- a/src/main/java/com/example/project/api/service/KakaoUriBuilderService.java
+++ b/src/main/java/com/example/project/api/service/KakaoUriBuilderService.java
@@ -12,12 +12,32 @@ public class KakaoUriBuilderService {
 
     private static final String KAKAO_LOCAL_SEARCH_ADDRESS_URL = "https://dapi.kakao.com/v2/local/search/address.json";
 
+    private static final String KAKAO_LOCAL_CATEGORY_SEARCH_URL = "https://dapi.kakao.com/v2/local/search/category.json";
+
     public URI buildUriByAddressSearch(String address) {
         UriComponentsBuilder uriBuilder = UriComponentsBuilder.fromHttpUrl(KAKAO_LOCAL_SEARCH_ADDRESS_URL);
         uriBuilder.queryParam("query", address); // query=전북 삼성동 100
 
         URI uri = uriBuilder.build().encode().toUri();
         log.info("[KakaoUriBuilderService buildUriByAddressSearch] address: {}, uri: {}", address, uri);
+
+        return uri;
+    }
+
+    public URI buildUriByCategorySearch(double latitude, double longitude, double radius, String category) {
+
+        double meterRadius = radius * 1000;
+
+        UriComponentsBuilder uriBuilder = UriComponentsBuilder.fromHttpUrl(KAKAO_LOCAL_CATEGORY_SEARCH_URL);
+        uriBuilder.queryParam("category_group_code", category);
+        uriBuilder.queryParam("x", longitude);
+        uriBuilder.queryParam("y", latitude);
+        uriBuilder.queryParam("radius", meterRadius);
+        uriBuilder.queryParam("sort","distance");
+
+        URI uri = uriBuilder.build().encode().toUri();
+
+        log.info("[KakaoAddressSearchService buildUriByCategorySearch] uri: {} ", uri);
 
         return uri;
     }

--- a/src/main/java/com/example/project/pharmacy/service/PharmacyRecommendationService.java
+++ b/src/main/java/com/example/project/pharmacy/service/PharmacyRecommendationService.java
@@ -32,10 +32,10 @@ public class PharmacyRecommendationService {
 
         DocumentDto documentDto = kakaoApiResponseDto.getDocumentList().get(0);
 
-        List<Direction> directionList = directionService.buildDirectionList(documentDto);
+//        List<Direction> directionList = directionService.buildDirectionList(documentDto);
+        List<Direction> directionList1 = directionService.buildDirectionListByCategoryApi(documentDto);
 
-        directionService.saveAll(directionList);
-
-
+//        directionService.saveAll(directionList);
+        directionService.saveAll(directionList1);
     }
 }


### PR DESCRIPTION
여태까지는 DB에 저장된 약국 위치의 데이터로 각까운 약국을 찾았지만 DB에 저장된 약국 데이터는 실시간 데이터가 아니여서 실제 정보와 다를 수 있다. 그래서 카카오 카테고리로 장소 검색하기 api를 사용하여 약국을 검색할 수 있게 했다.

This closes #18 